### PR TITLE
Needed #include <cmath> to fix compile error on "std::isnan(value)".

### DIFF
--- a/cpc/include/cpc_sketch.hpp
+++ b/cpc/include/cpc_sketch.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cmath>
 
 #include "fm85.h"
 #include "fm85Compression.h"


### PR DESCRIPTION
I also get two compiler warnings:

moving a local object in a return statement prevents copy elision [-Wpessimizing-move]	cpc_sketch.hpp	/sketches-core-cpp/cpc/include	line 385	C/C++ Problem

moving a local object in a return statement prevents copy elision [-Wpessimizing-move]	cpc_sketch.hpp	/sketches-core-cpp/cpc/include	line 483	C/C++ Problem

Please check.